### PR TITLE
fix: Featured Speakers 圖片重複載入

### DIFF
--- a/components/home/FeaturedSpeakers.vue
+++ b/components/home/FeaturedSpeakers.vue
@@ -107,7 +107,7 @@ function handlePrev() {
             scale: 2,
             duration: 0.5,
             backgroundColor: 'rgba(0, 46, 255, 0.9)',
-            text: '⭠',
+            icon: 'arrow-left',
           }"
           type="button"
           class="absolute left-0 top-0 h-full w-20"
@@ -119,7 +119,7 @@ function handlePrev() {
             scale: 2,
             duration: 0.5,
             backgroundColor: 'rgba(0, 46, 255, 0.9)',
-            text: '⭢',
+            icon: 'arrow-right',
           }"
           type="button"
           class="absolute right-0 top-0 h-full w-20"

--- a/components/home/FeaturedSpeakers.vue
+++ b/components/home/FeaturedSpeakers.vue
@@ -88,9 +88,9 @@ function handlePrev() {
             v-for="(speaker, index) in SPEAKERS"
             :key="speaker.name"
             :class="{
-              'border-l-[0.5px]': index !== 0,
+              'border-l-[0.5px]': index === 0,
             }"
-            class="col-span-1 flex flex-col items-center justify-center px-12 py-10"
+            class="col-span-1 flex flex-col items-center justify-center border-r-[0.5px] px-12 py-10"
           >
             <HomeSpeakerCard
               :ref="(el) => (speakerCards[index] = el)"

--- a/components/home/SpeakerCard.vue
+++ b/components/home/SpeakerCard.vue
@@ -85,8 +85,8 @@ function slideToPrev() {
 
   timeline.to(cardContainer.value, {
     x: 0,
-    duration: 1,
-    ease: 'power2.inOut',
+    duration: 0.8,
+    ease: 'none',
     force3D: true,
     willChange: 'transform',
   })
@@ -147,6 +147,18 @@ watch(
     }"
     class="relative w-full max-w-full overflow-hidden"
   >
+    <!-- 預載所有圖片 -->
+    <div class="hidden">
+      <NuxtImg
+        v-for="speaker in speakers"
+        :key="speaker.src"
+        :src="speaker.src"
+        width="264"
+        height="376"
+        loading="eager"
+      />
+    </div>
+
     <div
       ref="cardContainer"
       class="flex w-[200%]"
@@ -158,13 +170,13 @@ watch(
         class="w-1/2 shrink-0"
       >
         <div class="group relative">
-          <NuxtImg
-            :src="currentSpeaker.src"
-            alt="speaker"
-            width="264"
-            height="376"
-            class="grayscale duration-300 group-hover:grayscale-0"
-          />
+          <div
+            class="h-[376px] w-[264px] bg-cover bg-center grayscale group-hover:grayscale-0"
+            :style="{
+              backgroundImage: `url(${currentSpeaker.src})`,
+              transition: 'filter 0.3s',
+            }"
+          ></div>
 
           <ShareGradientMask class="group-hover:opacity-0" />
           <ShareNoiseMask class="group-hover:opacity-0" />
@@ -178,13 +190,13 @@ watch(
       <!-- 下一張講者卡片 -->
       <div class="w-1/2 shrink-0">
         <div class="group relative">
-          <NuxtImg
-            :src="nextSpeaker.src"
-            alt="speaker"
-            width="264"
-            height="376"
-            class="grayscale duration-300 group-hover:grayscale-0"
-          />
+          <div
+            class="h-[376px] w-[264px] bg-cover bg-center grayscale group-hover:grayscale-0"
+            :style="{
+              backgroundImage: `url(${nextSpeaker.src})`,
+              transition: 'filter 0.3s',
+            }"
+          ></div>
           <ShareGradientMask class="group-hover:opacity-0" />
           <ShareNoiseMask class="group-hover:opacity-0" />
         </div>

--- a/public/images/icon/arrow-left.svg
+++ b/public/images/icon/arrow-left.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M10.6667 19L4 12M4 12L10.6667 5M4 12L20 12" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.6667 19L4 12M4 12L10.6667 5M4 12L20 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/images/icon/arrow-right.svg
+++ b/public/images/icon/arrow-right.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M13.3333 5L20 12M20 12L13.3333 19M20 12L4 12" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.3333 5L20 12M20 12L13.3333 19M20 12L4 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->

- fix: 將 NuxtImg 替換成有 background-image 的 div，並且提前預載入所有圖片
- feat: 卡片容器最左邊與最右邊都加上 border
- feat: 修改輪播按鈕的圖示，改以 props.icon 指定



### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。