### PR TITLE
fix: 修復存取不到 p5 實例導致 console 報錯的問題

### DIFF
--- a/composables/useP5.ts
+++ b/composables/useP5.ts
@@ -17,11 +17,17 @@ export function useP5Sketch({ container, sketch }: P5SketchOptions) {
   }
 
   const createSketch = () => {
+    if (!process.client)
+      return
+
+    if (!$p5)
+      return
+
     if (p5Instance) {
       destroySketch()
     }
 
-    if (container.value && $p5) {
+    if (container.value) {
       p5Instance = new $p5(sketch, container.value)
     }
   }


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->

- fix: 在 useP5Sketch 中加入 client 端的判斷，避免 SSR 階段就操作 p5 實例




### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。