### PR TITLE
fix: 調整講者輪播特效與素材

### DIFF
--- a/components/home/FeaturedSpeakerCard.vue
+++ b/components/home/FeaturedSpeakerCard.vue
@@ -47,7 +47,7 @@ function slideToNext() {
   // 向左滑動到下一張卡片位置
   timeline.to(cardContainer.value, {
     x: '-50%',
-    duration: 1,
+    duration: 0.8,
     ease: 'power2.inOut',
     force3D: true,
     willChange: 'transform',

--- a/components/home/FeaturedSpeakerCard.vue
+++ b/components/home/FeaturedSpeakerCard.vue
@@ -165,7 +165,7 @@ watch(
         >
           <div class="group relative">
             <div
-              class="aspect-speaker-img w-full bg-cover bg-center grayscale group-hover:grayscale-0"
+              class="aspect-speaker-img w-full bg-cover bg-center grayscale group-hover:grayscale-0 lg:aspect-speaker-img-full 3xl:aspect-speaker-img"
               :style="{
                 backgroundImage: `url(${speakers[currentIndex].src})`,
                 transition: 'filter 0.3s',
@@ -185,7 +185,7 @@ watch(
         <div class="w-1/2 shrink-0">
           <div class="group relative">
             <div
-              class="aspect-speaker-img w-full bg-cover bg-center grayscale group-hover:grayscale-0"
+              class="aspect-speaker-img w-full bg-cover bg-center grayscale group-hover:grayscale-0 lg:aspect-speaker-img-full 3xl:aspect-speaker-img"
               :style="{
                 backgroundImage: `url(${speakers[getNextIndex()].src})`,
                 transition: 'filter 0.3s',

--- a/components/home/FeaturedSpeakerCard.vue
+++ b/components/home/FeaturedSpeakerCard.vue
@@ -153,18 +153,6 @@ watch(
       }"
       class="relative w-full overflow-hidden"
     >
-      <!-- 預載入所有圖片 -->
-      <div class="hidden">
-        <NuxtImg
-          v-for="speaker in speakers"
-          :key="speaker.src"
-          :src="speaker.src"
-          width="282"
-          height="448"
-          loading="eager"
-        />
-      </div>
-
       <div
         ref="cardContainer"
         class="flex w-[200%]"

--- a/components/home/FeaturedSpeakers.vue
+++ b/components/home/FeaturedSpeakers.vue
@@ -122,7 +122,7 @@ function handlePrev() {
           @mouseleave="isHovered = false"
         >
           <!-- 講者卡片 -->
-          <HomeSpeakerCard
+          <HomeFeaturedSpeakerCard
             v-for="index in displayCardLengthArr"
             :key="speakerAssets[index].name"
             :ref="(el) => (speakerCards[index] = el)"

--- a/components/share/GradientMask.vue
+++ b/components/share/GradientMask.vue
@@ -1,5 +1,5 @@
 <template>
   <div
-    class="absolute inset-0 bg-gradient-to-b from-black to-webconf-blue mix-blend-plus-lighter duration-300"
+    class="absolute inset-0 bg-gradient-to-b from-transparent to-webconf-blue mix-blend-screen duration-300"
   ></div>
 </template>

--- a/components/share/NoiseMask.vue
+++ b/components/share/NoiseMask.vue
@@ -1,26 +1,85 @@
 <template>
   <div
-    class="pointer-events-none absolute inset-0 mix-blend-multiply duration-300"
+    class="pointer-events-none absolute inset-0 opacity-35 mix-blend-multiply duration-300"
   >
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      style="filter: grayscale(0)"
       class="size-full"
     >
-      <filter id="noiseFilter">
-        <feTurbulence
-          type="fractalNoise"
-          baseFrequency="1.5"
-          numOctaves="3"
-          stitchTiles="stitch"
+      <g
+        xmlns="http://www.w3.org/2000/svg"
+        filter="url(#filter0_n_40000750_27464)"
+      >
+        <rect
+          width="100%"
+          height="100%"
+          fill="white"
         />
-      </filter>
-
-      <rect
-        width="100%"
-        height="100%"
-        filter="url(#noiseFilter)"
-      />
+      </g>
+      <defs xmlns="http://www.w3.org/2000/svg">
+        <filter
+          id="filter0_n_40000750_27464"
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          filterUnits="userSpaceOnUse"
+          color-interpolation-filters="sRGB"
+        >
+          <feFlood
+            flood-opacity="0"
+            result="BackgroundImageFix"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="BackgroundImageFix"
+            result="shape"
+          />
+          <feTurbulence
+            type="fractalNoise"
+            baseFrequency="4.5164947509765625 4.5164947509765625"
+            stitchTiles="stitch"
+            numOctaves="3"
+            result="noise"
+            seed="9023"
+          />
+          <feColorMatrix
+            in="noise"
+            type="luminanceToAlpha"
+            result="alphaNoise"
+          />
+          <feComponentTransfer
+            in="alphaNoise"
+            result="coloredNoise1"
+          >
+            <feFuncA
+              type="discrete"
+              tableValues="1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 "
+            />
+          </feComponentTransfer>
+          <feComposite
+            operator="in"
+            in2="shape"
+            in="coloredNoise1"
+            result="noise1Clipped"
+          />
+          <feFlood
+            flood-color="rgba(0, 0, 0, 0.2)"
+            result="color1Flood"
+          />
+          <feComposite
+            operator="in"
+            in2="noise1Clipped"
+            in="color1Flood"
+            result="color1"
+          />
+          <feMerge result="effect1_noise_40000750_27464">
+            <feMergeNode in="shape" />
+            <feMergeNode in="color1" />
+          </feMerge>
+        </filter>
+      </defs>
     </svg>
   </div>
 </template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -113,6 +113,7 @@ export default {
       },
       aspectRatio: {
         'speaker-img': '282 / 448',
+        'speaker-img-full': '264 / 376',
       },
     },
   },


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->

- fix: 移除不必要的 NuxtImg 載入
- feat: 調整噪點濾鏡，以素材代替原始運算
- feat: 調整輪播 4 欄圖片的比例
- fix: 統一輪播進行的時間

### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。