### PR TITLE
fix: 修正議程列表內文排列

### DIFF
--- a/pages/agenda.vue
+++ b/pages/agenda.vue
@@ -368,7 +368,7 @@ const AGENDA_LIST: AgendaItem[] = [
             class="flex flex-col gap-10 border-b-[0.5px] border-b-webconf-gray px-5 pb-10 pt-6 sm:flex-row sm:justify-between sm:px-10 sm:pb-[68px] sm:pt-8"
           >
             <!-- 議程主題 -->
-            <div class="sm:flex-[5]">
+            <div class="sm:flex-[3] lg:flex-[5]">
               <h2 class="text-h3-40 leading-[1.1]">
                 {{ item.topic }}
               </h2>


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->
- fix: 調整議程主體與講者資訊在 sm 至 lg 之間的佔比


### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。