### PR TITLE
fix: 調整議程資訊的 hover 在同步聯播項目的縮放倍率

### DIFF
--- a/components/agenda/Card.vue
+++ b/components/agenda/Card.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { AgendaItem } from '~/types'
 
-defineProps<{
+const props = defineProps<{
   data: AgendaItem
   index: number
   time?: string
@@ -9,18 +9,44 @@ defineProps<{
   isSelected: boolean
 }>()
 
+// 常數定義
+const BLOCK_SIZE_MOBILE = 20
+const BLOCK_SIZE_DESKTOP = 28
+const LG_BREAKPOINT = 1024
+
 const cardRef = ref<HTMLElement>()
 const { setToggleModal } = useGlobalState()
 const { width, height } = useElementSize(cardRef, undefined, {
   box: 'border-box',
 })
 
-// 根據螢幕尺寸決定初始方塊大小 (行動版 20px, 桌面版 28px)
-const initialSize = computed(() => (width.value >= 1280 ? 28 : 20))
+// 根據螢幕尺寸決定初始方塊大小
+const initialSize = computed(() => {
+  if (process.client && window.innerWidth >= LG_BREAKPOINT) {
+    return BLOCK_SIZE_DESKTOP
+  }
+  return BLOCK_SIZE_MOBILE
+})
 
-// 計算 X 和 Y 軸各自需要的縮放比例，讓兩個方向同時到達邊界
+// 計算縮放比例
 const scaleX = computed(() => width.value / initialSize.value)
 const scaleY = computed(() => height.value / initialSize.value)
+
+// lg 斷點時，scaleX 會乘以 space 值
+const scaleXForLg = computed(() => scaleX.value * (props.data.space ?? 1))
+
+// 計算屬性
+const isSpecialCard = computed(() => {
+  return props.data.title === '同步聯播' || props.data.title === 'TBD'
+})
+
+const cardLink = computed(() => {
+  if (props.data.speakerInfo && props.data.speakerInfo.length > 0) {
+    const speakerIds = props.data.speakerInfo.map(s => s.speakerId).join('/')
+    return `/agenda/${speakerIds}`
+  }
+  return '/agenda'
+})
 </script>
 
 <template>
@@ -39,31 +65,28 @@ const scaleY = computed(() => height.value / initialSize.value)
     <!-- 議程卡片 -->
     <NuxtLink
       ref="cardRef"
-      class="group relative block h-full overflow-hidden bg-black transition-colors duration-300"
+      class="group relative block h-full bg-black transition-colors duration-300 lg:overflow-visible"
       :class="{
         'lg:-mt-7': showTime,
       }"
-      :to="
-        data.speakerInfo && data.speakerInfo.length > 0
-          ? `/agenda/${data.speakerInfo.map((s) => s.speakerId).join('/')}`
-          : '/agenda'
-      "
+      :to="cardLink"
       @click="setToggleModal(true)"
     >
       <!-- 縮放特效方塊 -->
       <div
-        v-if="data.title !== '同步聯播' && data.title !== 'TBD'"
-        class="absolute left-0 top-0 z-0 size-5 origin-top-left bg-webconf-blue transition-transform duration-300 ease-out group-hover:[transform:scale(var(--scale-x),var(--scale-y))] lg:block lg:size-7"
+        v-if="!isSpecialCard"
+        class="pointer-events-none absolute left-0 top-0 z-10 size-5 origin-top-left bg-webconf-blue mix-blend-screen transition-transform duration-300 ease-out lg:block lg:size-7 lg:group-hover:[transform:scale(var(--scale-x-lg),var(--scale-y))]"
         :style="{
           '--scale-x': scaleX,
           '--scale-y': scaleY,
+          '--scale-x-lg': scaleXForLg,
         }"
       ></div>
 
       <div class="h-full px-5 py-8 lg:px-10 xl:min-h-[285px]">
         <!-- 議程簡介 -->
         <div
-          v-if="data.title !== '同步聯播' && data.title !== 'TBD'"
+          v-if="!isSpecialCard"
           class="relative flex h-full flex-col gap-4"
         >
           <h2 class="text-h4-24 leading-[1.4]">
@@ -83,8 +106,9 @@ const scaleY = computed(() => height.value / initialSize.value)
             </li>
           </ul>
 
-          <div class="flex items-end justify-between">
+          <div class="z-10 flex items-end justify-between">
             <div class="flex items-end gap-3">
+              <!-- 講者頭像 -->
               <div class="flex gap-2">
                 <div
                   v-for="speaker in data.speakerInfo"
@@ -101,6 +125,7 @@ const scaleY = computed(() => height.value / initialSize.value)
                 </div>
               </div>
 
+              <!-- 講者名稱 -->
               <div
                 class="flex flex-col flex-wrap items-center gap-1 lg:flex-row lg:gap-2"
               >
@@ -111,7 +136,6 @@ const scaleY = computed(() => height.value / initialSize.value)
                   <p class="text-body-16">
                     {{ speaker.name }}
                   </p>
-
                   <p
                     v-if="data.speakerInfo && idx < data.speakerInfo.length - 1"
                     class="hidden text-[#999] lg:block"
@@ -122,6 +146,7 @@ const scaleY = computed(() => height.value / initialSize.value)
               </div>
             </div>
 
+            <!-- 地點 (行動版) -->
             <div class="flex items-center gap-1 text-body-18 lg:hidden">
               <NuxtImg
                 src="/images/icon/location.svg"
@@ -134,7 +159,7 @@ const scaleY = computed(() => height.value / initialSize.value)
           </div>
         </div>
 
-        <!-- 同步聯播 -->
+        <!-- 特殊卡片 (同步聯播/TBD) -->
         <div
           v-else
           class="flex h-full items-center justify-between"
@@ -143,6 +168,7 @@ const scaleY = computed(() => height.value / initialSize.value)
             {{ data.title }}
           </h2>
 
+          <!-- 地點 (行動版) -->
           <div class="flex items-center gap-1 text-body-18 lg:hidden">
             <NuxtImg
               src="/images/icon/location.svg"
@@ -157,11 +183,8 @@ const scaleY = computed(() => height.value / initialSize.value)
 
       <!-- 半透明遮罩 -->
       <div
-        class="absolute inset-0 size-full bg-black opacity-0 duration-300"
-        :class="{
-          'block opacity-70': !isSelected,
-          'hidden': isSelected,
-        }"
+        v-if="!isSelected"
+        class="absolute inset-0 size-full bg-black opacity-70 duration-300"
       ></div>
     </NuxtLink>
   </div>

--- a/components/agenda/Card.vue
+++ b/components/agenda/Card.vue
@@ -9,36 +9,21 @@ const props = defineProps<{
   isSelected: boolean
 }>()
 
-// 常數定義
-const BLOCK_SIZE_MOBILE = 20
-const BLOCK_SIZE_DESKTOP = 28
-const LG_BREAKPOINT = 1024
-
 const cardRef = ref<HTMLElement>()
 const { setToggleModal } = useGlobalState()
 const { width, height } = useElementSize(cardRef, undefined, {
   box: 'border-box',
 })
 
-// 根據螢幕尺寸決定初始方塊大小
-const initialSize = computed(() => {
-  if (process.client && window.innerWidth >= LG_BREAKPOINT) {
-    return BLOCK_SIZE_DESKTOP
-  }
-  return BLOCK_SIZE_MOBILE
-})
-
-// 計算目標寬高（使用寬高動畫取代 scale，避免超出容器）
-const targetWidth = computed(() => width.value * (props.data.space ?? 1))
-const targetHeight = computed(() => height.value)
-
-// 計算初始和目標尺寸的 CSS 值
-const blockStyle = computed(() => {
-  const baseSize = initialSize.value
+// 計算目標尺寸的 CSS 值
+const squareStyle = computed(() => {
+  const targetWidth
+    = Math.ceil(width.value) * (props.data.space ?? 1)
+      + (props.data.space ?? 0.5)
+  const targetHeight = Math.ceil(height.value)
   return {
-    '--initial-size': `${baseSize}px`,
-    '--target-width': `${targetWidth.value}px`,
-    '--target-height': `${targetHeight.value}px`,
+    '--target-width': `${targetWidth}px`,
+    '--target-height': `${targetHeight}px`,
   }
 })
 
@@ -58,7 +43,9 @@ const cardLink = computed(() => {
 
 <template>
   <div
-    :class="{ 'lg:border-r-[0.5px]': index !== 2 }"
+    :class="{
+      'lg:border-r-[0.5px]': index !== 2,
+    }"
     class="relative grow border-b-[0.5px] border-webconf-gray/50"
   >
     <!-- 時間標記 (桌面版) -->
@@ -69,7 +56,6 @@ const cardLink = computed(() => {
       {{ time }}
     </div>
 
-    <!-- 議程卡片 -->
     <NuxtLink
       ref="cardRef"
       class="group relative block h-full bg-black transition-colors duration-300 lg:overflow-visible"
@@ -79,15 +65,13 @@ const cardLink = computed(() => {
       :to="cardLink"
       @click="setToggleModal(true)"
     >
-      <!-- 縮放特效方塊 -->
       <div
         v-if="!isSpecialCard"
         class="pointer-events-none absolute left-0 top-0 z-10 size-5 bg-webconf-blue mix-blend-screen transition-all duration-300 ease-out lg:block lg:size-7 lg:group-hover:h-[var(--target-height)] lg:group-hover:w-[var(--target-width)]"
-        :style="blockStyle"
+        :style="squareStyle"
       ></div>
 
       <div class="h-full px-5 py-8 lg:px-10 xl:min-h-[285px]">
-        <!-- 議程簡介 -->
         <div
           v-if="!isSpecialCard"
           class="relative flex h-full flex-col gap-4"
@@ -112,11 +96,17 @@ const cardLink = computed(() => {
           <div class="z-10 flex items-end justify-between">
             <div class="flex items-end gap-3">
               <!-- 講者頭像 -->
-              <div class="flex gap-2">
+              <div class="flex shrink-0 gap-2">
                 <div
-                  v-for="speaker in data.speakerInfo"
+                  v-for="(speaker, idx) in data.speakerInfo"
                   :key="speaker.name"
                   class="relative"
+                  :style="{
+                    transform:
+                      data.speakerInfo?.length && data.speakerInfo.length > 2
+                        ? `translateX(${-50 * idx}%)`
+                        : undefined,
+                  }"
                 >
                   <NuxtImg
                     :src="speaker.avatarUrl"
@@ -130,7 +120,11 @@ const cardLink = computed(() => {
 
               <!-- 講者名稱 -->
               <div
-                class="flex flex-col flex-wrap items-center gap-1 lg:flex-row lg:gap-2"
+                class="flex min-w-[50%] flex-col flex-wrap items-center gap-1 lg:flex-row lg:gap-[6px]"
+                :class="{
+                  'ml-[-43px]':
+                    data.speakerInfo?.length && data.speakerInfo.length > 2,
+                }"
               >
                 <template
                   v-for="(speaker, idx) in data.speakerInfo"
@@ -162,7 +156,7 @@ const cardLink = computed(() => {
           </div>
         </div>
 
-        <!-- 特殊卡片 (同步聯播/TBD) -->
+        <!-- 同步聯播 / TBD -->
         <div
           v-else
           class="flex h-full items-center justify-between"

--- a/components/agenda/Card.vue
+++ b/components/agenda/Card.vue
@@ -28,12 +28,19 @@ const initialSize = computed(() => {
   return BLOCK_SIZE_MOBILE
 })
 
-// 計算縮放比例
-const scaleX = computed(() => width.value / initialSize.value)
-const scaleY = computed(() => height.value / initialSize.value)
+// 計算目標寬高（使用寬高動畫取代 scale，避免超出容器）
+const targetWidth = computed(() => width.value * (props.data.space ?? 1))
+const targetHeight = computed(() => height.value)
 
-// lg 斷點時，scaleX 會乘以 space 值
-const scaleXForLg = computed(() => scaleX.value * (props.data.space ?? 1))
+// 計算初始和目標尺寸的 CSS 值
+const blockStyle = computed(() => {
+  const baseSize = initialSize.value
+  return {
+    '--initial-size': `${baseSize}px`,
+    '--target-width': `${targetWidth.value}px`,
+    '--target-height': `${targetHeight.value}px`,
+  }
+})
 
 // 計算屬性
 const isSpecialCard = computed(() => {
@@ -75,12 +82,8 @@ const cardLink = computed(() => {
       <!-- 縮放特效方塊 -->
       <div
         v-if="!isSpecialCard"
-        class="pointer-events-none absolute left-0 top-0 z-10 size-5 origin-top-left bg-webconf-blue mix-blend-screen transition-transform duration-300 ease-out lg:block lg:size-7 lg:group-hover:[transform:scale(var(--scale-x-lg),var(--scale-y))]"
-        :style="{
-          '--scale-x': scaleX,
-          '--scale-y': scaleY,
-          '--scale-x-lg': scaleXForLg,
-        }"
+        class="pointer-events-none absolute left-0 top-0 z-10 size-5 bg-webconf-blue mix-blend-screen transition-all duration-300 ease-out lg:block lg:size-7 lg:group-hover:h-[var(--target-height)] lg:group-hover:w-[var(--target-width)]"
+        :style="blockStyle"
       ></div>
 
       <div class="h-full px-5 py-8 lg:px-10 xl:min-h-[285px]">
@@ -181,10 +184,10 @@ const cardLink = computed(() => {
         </div>
       </div>
 
-      <!-- 半透明遮罩 -->
+      <!-- 標籤選取遮罩 -->
       <div
         v-if="!isSelected"
-        class="absolute inset-0 size-full bg-black opacity-70 duration-300"
+        class="absolute inset-0 z-10 size-full bg-black opacity-70 duration-300"
       ></div>
     </NuxtLink>
   </div>

--- a/constants/agenda.ts
+++ b/constants/agenda.ts
@@ -18,6 +18,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '09:10',
     endTime: '09:55',
     location: 'A2 棟',
+    space: 3,
   },
   {
     title: '同步聯播',
@@ -25,6 +26,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '09:10',
     endTime: '09:55',
     location: 'M 棟',
+    tags: ['AI', '產品思維', '產業應用', '團隊管理'],
   },
   {
     title: '同步聯播',
@@ -32,6 +34,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '09:10',
     endTime: '09:55',
     location: 'F 棟',
+    tags: ['AI', '產品思維', '產業應用', '團隊管理'],
   },
   // 12/12 10:05 - 10:50
   {
@@ -200,6 +203,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '13:30',
     endTime: '14:15',
     location: 'M 棟',
+    space: 2,
   },
   {
     title: '同步聯播',
@@ -207,6 +211,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '13:30',
     endTime: '14:15',
     location: 'F 棟',
+    tags: ['Frontend', 'AI'],
   },
   // 12/12 14:25 - 15:10
   {
@@ -395,9 +400,11 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '09:00',
     endTime: '09:45',
     location: 'M 棟',
+    space: 2,
   },
   {
     title: '同步聯播',
+    tags: ['Frontend', 'Backend', 'Security'],
     day: '13',
     startTime: '09:00',
     endTime: '09:45',
@@ -593,6 +600,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '13:30',
     endTime: '14:15',
     location: 'M 棟',
+    space: 2,
   },
   {
     title: '同步聯播',
@@ -600,6 +608,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '13:30',
     endTime: '14:15',
     location: 'F 棟',
+    tags: ['AI'],
   },
   // 12/13 14:25 - 15:10
   {
@@ -736,6 +745,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '16:15',
     endTime: '17:00',
     location: 'A2 棟',
+    space: 3,
   },
   {
     title: '同步聯播',
@@ -743,6 +753,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '16:15',
     endTime: '17:00',
     location: 'M 棟',
+    tags: ['AI', '產品思維', '軟體設計'],
   },
   {
     title: '同步聯播',
@@ -750,6 +761,7 @@ export const AGENDA_LIST: AgendaItem[] = [
     startTime: '16:15',
     endTime: '17:00',
     location: 'F 棟',
+    tags: ['AI', '產品思維', '軟體設計'],
   },
 ]
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,4 +27,5 @@ export interface AgendaItem {
   startTime: string
   endTime: string
   location: string
+  space?: 1 | 2 | 3
 }


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->
- fix: 新增 AgendaItem 的屬性 'space'，使 AgendaCard 的縮放特效依此倍率進行
- refactor: 使用寬高變化取代 scale 縮放，防止小數點計算偏差
- fix: 修正講者座談的多個照片與名字的排版問題


### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。