### PR TITLE
fix: 修正講者照片在行動版時會穿過時間標籤的問題

### DIFF
--- a/components/agenda/Card.vue
+++ b/components/agenda/Card.vue
@@ -93,7 +93,7 @@ const cardLink = computed(() => {
             </li>
           </ul>
 
-          <div class="z-10 flex items-end justify-between">
+          <div class="flex items-end justify-between lg:z-10">
             <div class="flex items-end gap-3">
               <!-- 講者頭像 -->
               <div class="flex shrink-0 gap-2">


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->
- fix: 修正講者照片在行動版時會穿過時間標籤的問題


### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。