### PR TITLE
fix: 修正卡片遮罩在選單打開時的透明度

### DIFF
--- a/components/agenda/Card.vue
+++ b/components/agenda/Card.vue
@@ -7,6 +7,7 @@ const props = defineProps<{
   time?: string
   showTime?: boolean
   isSelected: boolean
+  isMenuOpen: boolean
 }>()
 
 const cardRef = ref<HTMLElement>()
@@ -166,7 +167,11 @@ const cardLink = computed(() => {
 
       <!-- 標籤選取遮罩 -->
       <div
-        v-if="!isSelected"
+        v-if="!isSelected && !isMenuOpen"
+        :class="{
+          'opacity-0': isSelected || isMenuOpen,
+          'opacity-70': !isSelected && !isMenuOpen,
+        }"
         class="absolute inset-0 z-[5] size-full bg-black opacity-70 duration-300"
       ></div>
     </NuxtLink>

--- a/components/share/GridCard.vue
+++ b/components/share/GridCard.vue
@@ -3,6 +3,7 @@ interface Props {
   isSelected?: boolean
   disabledSquareEffect?: boolean
   showSquare?: boolean
+  isMenuOpen?: boolean
 }
 
 const {
@@ -58,7 +59,11 @@ const scaleY = computed(() => {
 
     <!-- 半透明遮罩 -->
     <div
-      v-if="isSelected === false"
+      v-if="!isSelected && !isMenuOpen"
+      :class="{
+        'opacity-0': isSelected || isMenuOpen,
+        'opacity-70': !isSelected && !isMenuOpen,
+      }"
       class="absolute inset-0 z-10 size-full bg-black opacity-70 duration-300"
     ></div>
 

--- a/pages/agenda.vue
+++ b/pages/agenda.vue
@@ -235,6 +235,7 @@ watch(isMenuOpen, (newValue) => {
               <AgendaCard
                 v-for="(agenda, index) in agendas"
                 :key="`${time}-${index}`"
+                :is-menu-open="isMenuOpen"
                 :data="agenda"
                 :index="index"
                 :time="time"
@@ -288,6 +289,7 @@ watch(isMenuOpen, (newValue) => {
               <AgendaCard
                 v-for="(agenda, index) in agendas"
                 :key="`${time}-${index}`"
+                :is-menu-open="isMenuOpen"
                 :data="agenda"
                 :index="index"
                 :time="time"

--- a/pages/speakers.vue
+++ b/pages/speakers.vue
@@ -116,6 +116,7 @@ watch(isMenuOpen, (newValue) => {
             :to="`/speakers/${speaker.speakerId}`"
           >
             <ShareGridCard
+              :is-menu-open="isMenuOpen"
               :is-selected="
                 speaker.tags?.some((tag) => selectedTags.includes(tag))
                   || selectedTags.length === 0


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->

- fix: 在卡片元件新增接口 isMenuOpe，使卡片遮罩在選單打開時不顯示

### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。