### PR TITLE
perf: 在載入動畫時同時執行講者資料讀取，改善第一次點擊議程資料時顯示較慢的問題

### DIFF
--- a/composables/useAllSpeakers.ts
+++ b/composables/useAllSpeakers.ts
@@ -1,0 +1,4 @@
+export function useAllSpeakers() {
+  return useAsyncData('all-speakers', () =>
+    queryCollection('content').all())
+}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,6 +6,8 @@ const shouldShowLoading = computed(() => {
   return route.name !== 'all'
 })
 
+await useAllSpeakers()
+
 // 404 頁面就不顯示首次加載動畫
 if (!shouldShowLoading.value) {
   setFirstLoad(true)

--- a/pages/agenda/[...speakerId].vue
+++ b/pages/agenda/[...speakerId].vue
@@ -9,8 +9,7 @@ const ALLOWED_MULTI_SPEAKER_GROUPS = [
   ['00', '23', '24'], // 第三場
 ]
 
-const { data: allSpeakers } = await useAsyncData('all-speakers', () =>
-  queryCollection('content').all())
+const { data: allSpeakers } = await useAllSpeakers()
 
 const currentSpeaker = computed(() => {
   const speakerIds = route.params.speakerId

--- a/pages/speakers/[...speakerId].vue
+++ b/pages/speakers/[...speakerId].vue
@@ -3,8 +3,7 @@ const route = useRoute('speakers-speakerId')
 const router = useRouter()
 const { setToggleModal } = useGlobalState()
 
-const { data: allSpeakers } = await useAsyncData('all-speakers', () =>
-  queryCollection('content').all())
+const { data: allSpeakers } = await useAllSpeakers()
 
 const currentSpeaker = computed(() => {
   const speakerIds = route.params.speakerId


### PR DESCRIPTION
<!---
☝️ PR 標題應符合 conventional commits 規範 (https://conventionalcommits.org)
範例 : docs(#123): improve environment setup guide
-->

### 🔗 Linked issue
<!-- 若此 PR 是解決未完成的 issue，請使用 "#" 連結該 issue，例如 #123 -->



### 📚 Description
<!-- 描述此 PR 更動的詳細內容 -->
<!-- 為什麼需提交此更改？它解決什麼問題？ -->

- perf: 將讀取講者資料的 fetch 抽象成 composable，並在 default layout 中與頁面載入動畫同時執行

### 📝 Checklist
<!-- 在以下適用項目的 [ ] 括號中填寫 "x" -->

- [ ] 我已經將此 PR 標註連結到關聯的 [Issue](https://github.com/webconf-taiwan/website/issues) 中。
- [x] 此 PR 不需要更新文件。